### PR TITLE
feat: Implement email notifications for test invitations

### DIFF
--- a/app/api/tests/route.ts
+++ b/app/api/tests/route.ts
@@ -1,4 +1,7 @@
 import { NextResponse } from 'next/server';
+import { sendTestInvitationEmail } from '../../lib/email'; // Import the email function
+import { getUserById, User } from '../../lib/data'; // Import user functions and type
+import { Test } from '../../lib/api/test-api'; // Import Test type
 
 // Proxy to backend API
 export async function GET(request: Request) {
@@ -11,6 +14,7 @@ export async function GET(request: Request) {
     const data = await response.json();
     return NextResponse.json(data);
   } catch (error) {
+    console.error('Failed to fetch test list:', error); // Added console.error for logging
     return NextResponse.json(
       { code: '500', message: 'Failed to fetch test list', data: null },
       { status: 500 }
@@ -27,11 +31,40 @@ export async function POST(request: Request) {
       body: JSON.stringify(testData),
     });
     const data = await response.json();
+
+    // Check if the test was created successfully before sending email
+    if (response.ok && data.code === '201') { // Assuming '201' is the success code from backend
+      const newTest = data.data as Test; // Cast the response data to Test type
+      if (newTest && newTest.user_id && newTest.activate_code) {
+        const user = getUserById(newTest.user_id); // Fetch user details
+
+        if (user && user.email) {
+          try {
+            await sendTestInvitationEmail(user, newTest);
+            console.log(`Invitation email sent to ${user.email} for test ID ${newTest.test_id}`);
+          } catch (emailError) {
+            console.error(`Failed to send invitation email for test ID ${newTest.test_id}:`, emailError);
+            // Do not block the response if email sending fails, but log the error.
+          }
+        } else {
+          console.warn(`User not found or email missing for user ID ${newTest.user_id} for test ID ${newTest.test_id}. Email not sent.`);
+        }
+      } else {
+        console.warn('Test created, but user_id or activate_code missing in the response. Email not sent.', newTest);
+      }
+    } else if (!response.ok) {
+      // If the response status is not ok, log the error and return it.
+      console.error('Failed to create test, backend response:', data);
+      return NextResponse.json(data, { status: response.status });
+    }
+    // Return the original response from the test creation API
     return NextResponse.json(data, { status: response.status });
+
   } catch (error) {
+    console.error('Failed to create test or send email:', error); // Log the error
     return NextResponse.json(
       { code: '500', message: 'Failed to create test', data: null },
       { status: 500 }
     );
   }
-} 
+}

--- a/app/lib/email.ts
+++ b/app/lib/email.ts
@@ -1,0 +1,61 @@
+import nodemailer from 'nodemailer';
+import { User } from './data'; // Assuming User interface is in data.ts
+import { Test } from './api/test-api'; // Assuming Test interface is in test-api.ts
+
+interface EmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+async function sendEmail(options: EmailOptions): Promise<void> {
+  // Configure Nodemailer transporter
+  // IMPORTANT: Replace with actual email service configuration (e.g., SMTP details or service like SendGrid/Mailgun)
+  // For demonstration, this uses ethereal.email, which creates a test account.
+  // You'll need to replace this with your actual email sending configuration.
+  const transporter = nodemailer.createTransport({
+    host: 'smtp.ethereal.email',
+    port: 587,
+    auth: {
+      user: 'YOUR_ETHEREAL_USER', // Replace with Ethereal username
+      pass: 'YOUR_ETHEREAL_PASSWORD' // Replace with Ethereal password
+    }
+  });
+
+  try {
+    await transporter.sendMail({
+      from: '"AI Interview Platform" <noreply@example.com>', // Sender address
+      to: options.to,
+      subject: options.subject,
+      html: options.html,
+    });
+    console.log('Email sent successfully to:', options.to);
+    // For Ethereal, a preview URL will be logged if you don't have real SMTP creds
+    // console.log("Preview URL: %s", nodemailer.getTestMessageUrl(info));
+  } catch (error) {
+    console.error('Error sending email:', error);
+    throw new Error('Failed to send email');
+  }
+}
+
+export async function sendTestInvitationEmail(candidate: User, test: Test): Promise<void> {
+  const activationLink = `https://ai-interview-web-home-749e.vercel.app/chat?code=${test.activate_code}`;
+  const subject = 'Your AI Interview Invitation';
+  const htmlContent = `
+    <p>Dear ${candidate.name},</p>
+    <p>You have been invited to take an AI interview.</p>
+    <p>Your activation code is: <strong>${test.activate_code}</strong></p>
+    <p>Please click on the following link to start your interview:</p>
+    <p><a href="${activationLink}">${activationLink}</a></p>
+    <p>The test is valid from ${new Date(test.start_date).toLocaleString()} to ${new Date(test.expire_date).toLocaleString()}.</p>
+    <p>Good luck!</p>
+    <p>Best regards,</p>
+    <p>The AI Interview Platform Team</p>
+  `;
+
+  await sendEmail({
+    to: candidate.email,
+    subject: subject,
+    html: htmlContent,
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,14 @@
         "antd": "^5.12.2",
         "dotenv": "^16.5.0",
         "next": "^14.2.26",
+        "nodemailer": "^6.9.14",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.10.4",
+        "@types/nodemailer": "^6.4.15",
         "@types/react": "^18.2.42",
         "@types/react-dom": "^18.2.17",
         "eslint": "^8.56.0",
@@ -752,6 +754,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -4751,6 +4763,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "next": "^14.2.26",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "nodemailer": "^6.9.14"
   },
   "devDependencies": {
     "@types/node": "^20.10.4",
+    "@types/nodemailer": "^6.4.15",
     "@types/react": "^18.2.42",
     "@types/react-dom": "^18.2.17",
     "eslint": "^8.56.0",


### PR DESCRIPTION
This commit introduces a feature to automatically send email notifications to candidates when a new test is created for them.

Key changes include:
- Added `nodemailer` to handle email sending.
- Created a new email utility module (`app/lib/email.ts`) with a `sendTestInvitationEmail` function. This function constructs and sends an email containing the test activation code and a direct link to the interview platform. It is configured to use Ethereal.email for testing (requires you to input credentials).
- Modified the `POST /api/tests` endpoint in `app/api/tests/route.ts`:
    - After a test is successfully created via the external API, the system now retrieves the candidate's details (using their `user_id`).
    - If the candidate's email is found, the `sendTestInvitationEmail` function is called.
    - Added comprehensive logging for the email sending process.
    - Email sending failures are logged but do not block the primary test creation flow.
- Ensured that necessary types (`User`, `Test`) are correctly imported and used.

To test email sending, placeholder credentials in `app/lib/email.ts` for Ethereal.email must be replaced with actual Ethereal testing credentials.