### PR TITLE
Fix: Adjust mocked total_count for better pagination simulation

### DIFF
--- a/app/lib/api/job-api.ts
+++ b/app/lib/api/job-api.ts
@@ -36,11 +36,18 @@ export const jobApi = {
       // Mocking metadata as backend doesn't provide it for this endpoint
       const result: ApiResponse<Job[]> = await response.json();
       if (result.code === '0' && result.data) {
+        const fetchedItemsCount = result.data.length;
+        let total_count = skip + fetchedItemsCount;
+        if (fetchedItemsCount === pageSize) {
+          // If we fetched a full page, assume there's at least one more item to simulate more pages.
+          // The real API should provide the true total_count.
+          total_count += 1;
+        }
         result.metadata = {
-          total_count: result.data.length + skip, // This is an assumption, actual total should come from API
+          total_count: total_count,
           current_page: page,
-          total_pages: Math.ceil((result.data.length + skip) / pageSize), // Assumption
-          has_next: (result.data.length + skip) > page * pageSize, // Assumption
+          total_pages: Math.ceil(total_count / pageSize),
+          has_next: total_count > page * pageSize,
           has_previous: page > 1,
         };
       }

--- a/app/lib/api/question-api.ts
+++ b/app/lib/api/question-api.ts
@@ -53,11 +53,18 @@ export const questionApi = {
       // Mocking metadata as backend doesn't provide it for this endpoint
       const result: ApiResponse<Question[]> = await response.json();
       if (result.code === '0' && result.data) {
+        const fetchedItemsCount = result.data.length;
+        let total_count = skip + fetchedItemsCount;
+        if (fetchedItemsCount === pageSize) {
+          // If we fetched a full page, assume there's at least one more item to simulate more pages.
+          // The real API should provide the true total_count.
+          total_count += 1;
+        }
         result.metadata = {
-          total_count: result.data.length + skip, // This is an assumption, actual total should come from API
+          total_count: total_count,
           current_page: page,
-          total_pages: Math.ceil((result.data.length + skip) / pageSize), // Assumption
-          has_next: (result.data.length + skip) > page * pageSize, // Assumption
+          total_pages: Math.ceil(total_count / pageSize),
+          has_next: total_count > page * pageSize,
           has_previous: page > 1,
         };
       }

--- a/app/lib/api/user-api.ts
+++ b/app/lib/api/user-api.ts
@@ -64,11 +64,18 @@ export const userApi = {
       // Mocking metadata as backend doesn't provide it for this endpoint
       const result: ApiResponse<User[]> = await response.json();
       if (result.code === '0' && result.data) {
+        const fetchedItemsCount = result.data.length;
+        let total_count = skip + fetchedItemsCount;
+        if (fetchedItemsCount === pageSize) {
+          // If we fetched a full page, assume there's at least one more item to simulate more pages.
+          // The real API should provide the true total_count.
+          total_count += 1;
+        }
         result.metadata = {
-          total_count: result.data.length + skip, // This is an assumption, actual total should come from API
+          total_count: total_count,
           current_page: page,
-          total_pages: Math.ceil((result.data.length + skip) / pageSize), // Assumption
-          has_next: (result.data.length + skip) > page * pageSize, // Assumption
+          total_pages: Math.ceil(total_count / pageSize),
+          has_next: total_count > page * pageSize,
           has_previous: page > 1,
         };
       }


### PR DESCRIPTION
This pull request updates metadata calculation logic across multiple API modules to improve pagination handling and simulate more accurate total counts when the backend does not provide this information. The changes ensure consistent handling of `total_count`, `total_pages`, and `has_next` based on fetched data.

### Updates to metadata calculation logic:

* **`jobApi` in `app/lib/api/job-api.ts`:** Adjusted `total_count` calculation to account for fetched items and simulate additional pages when a full page is retrieved. Updated `total_pages` and `has_next` logic accordingly.

* **`questionApi` in `app/lib/api/question-api.ts`:** Applied the same improvements to `total_count`, `total_pages`, and `has_next` logic for question-related API responses.

* **`userApi` in `app/lib/api/user-api.ts`:** Enhanced metadata handling for user-related API responses, mirroring the changes made in `jobApi` and `questionApi`.- I updated the mocking logic in userApi, jobApi, and questionApi.
- If a full page of data is fetched (number of items === pageSize), I incremented the mocked `total_count`.
- This ensures that your frontend pagination controls indicate that more pages are available, providing a more realistic simulation when the backend doesn't return the true total count.