### PR TITLE
Feat: Add School column to student details table

### DIFF
--- a/app/components/dashboard/StudentDetailsSection.tsx
+++ b/app/components/dashboard/StudentDetailsSection.tsx
@@ -29,6 +29,7 @@ interface Student {
   Joining_Date: string | null; // Consider converting to Date object if needed for sorting/formatting
   Aadhar_No?: string | null;
   Select_Campus?: SelectCampus; // This is an object
+  Select_School1?: string | null; // Added for the school name
   Qualification?: string | null;
   Caste?: string | null;
   // Include other fields as needed, marking them as optional if they might be missing
@@ -79,6 +80,7 @@ const StudentDetailsSection: React.FC = () => {
             Joining_Date: item.Joining_Date || null,
             Aadhar_No: item.Aadhar_No || null,
             Select_Campus: item.Select_Campus || { Campus_Name: "N/A", ID: "", zc_display_value: "N/A" },
+            Select_School1: item.Select_School1 || null,
             Qualification: item.Qualification || null,
             Caste: item.Caste || null,
             // Spread remaining item properties
@@ -152,6 +154,14 @@ const StudentDetailsSection: React.FC = () => {
       render: (campus: SelectCampus) => campus?.Campus_Name || 'N/A',
       sorter: (a: Student, b: Student) =>
         (a.Select_Campus?.Campus_Name || '').localeCompare(b.Select_Campus?.Campus_Name || ''),
+    },
+    {
+      title: 'School',
+      dataIndex: 'Select_School1',
+      key: 'school',
+      render: (school: string | null) => school || 'N/A',
+      sorter: (a: Student, b: Student) =>
+        (a.Select_School1 || '').localeCompare(b.Select_School1 || ''),
     },
   ];
 


### PR DESCRIPTION
This pull request introduces changes to the `StudentDetailsSection` component in `app/components/dashboard/StudentDetailsSection.tsx` to include a new field, `Select_School1`, for displaying and sorting school names. The updates involve modifications to the `Student` interface, data mapping, and table configuration.

### Updates to `StudentDetailsSection`:

**Interface Changes:**
* Added a new optional field `Select_School1` to the `Student` interface for storing school names. (`[app/components/dashboard/StudentDetailsSection.tsxR32](diffhunk://#diff-025799340c0fb7aa71bfa7ac9e72be6d0ddb8fd852acd217e4b09ead6987a230R32)`)

**Data Mapping:**
* Updated the `StudentDetailsSection` data mapping logic to include the `Select_School1` field, defaulting to `null` if not provided. (`[app/components/dashboard/StudentDetailsSection.tsxR83](diffhunk://#diff-025799340c0fb7aa71bfa7ac9e72be6d0ddb8fd852acd217e4b09ead6987a230R83)`)

**Table Configuration:**
* Added a new column for `School` in the table, including rendering logic to display `N/A` when the field is null and a sorting mechanism for school names. (`[app/components/dashboard/StudentDetailsSection.tsxR158-R165](diffhunk://#diff-025799340c0fb7aa71bfa7ac9e72be6d0ddb8fd852acd217e4b09ead6987a230R158-R165)`)- I updated the `Student` interface in `StudentDetailsSection.tsx` to include the `Select_School1` field.
- I mapped the `Select_School1` field from the API response in the `fetchStudentData` function.
- I added a 'School' column to the table to display the school name, with a fallback to 'N/A'.
- I implemented a sorter for the new 'School' column.