### PR TITLE
I've adjusted the API calls to fix an issue where the 'Applicable Job…

### DIFF
--- a/app/lib/api/job-api.ts
+++ b/app/lib/api/job-api.ts
@@ -29,7 +29,7 @@ export interface UpdateJobRequest {
 // Job API
 export const jobApi = {
   // Get job list
-  async getJobs(page: number = 1, pageSize: number = 10): Promise<ApiResponse<Job[]>> {
+  async getJobs(page: number = 1, pageSize: number = 1000): Promise<ApiResponse<Job[]>> {
     try {
       const skip = (page - 1) * pageSize;
       const response = await fetch(`${API_BASE_URL}/job?skip=${skip}&limit=${pageSize}`);
@@ -38,17 +38,13 @@ export const jobApi = {
       if (result.code === '0' && result.data) {
         const fetchedItemsCount = result.data.length;
         let total_count = skip + fetchedItemsCount;
-        if (fetchedItemsCount === pageSize) {
-          // If we fetched a full page, assume there's at least one more item to simulate more pages.
-          // The real API should provide the true total_count.
-          total_count += 1;
-        }
+        // A simplified mock pagination that assumes this is all the data
         result.metadata = {
           total_count: total_count,
           current_page: page,
-          total_pages: Math.ceil(total_count / pageSize),
-          has_next: total_count > page * pageSize,
-          has_previous: page > 1,
+          total_pages: page,
+          has_next: false,
+          has_previous: false,
         };
       }
       return result;

--- a/app/lib/api/user-api.ts
+++ b/app/lib/api/user-api.ts
@@ -57,7 +57,7 @@ export const roleMap: Record<number, string> = {
 export const userApi = {
   // Get user list
   
-  async getUsers(page: number = 1, pageSize: number = 10): Promise<ApiResponse<User[]>> {
+  async getUsers(page: number = 1, pageSize: number = 1000): Promise<ApiResponse<User[]>> {
     try {
       const skip = (page - 1) * pageSize;
       const response = await fetch(`${API_BASE_URL}/user?skip=${skip}&limit=${pageSize}`);
@@ -66,17 +66,13 @@ export const userApi = {
       if (result.code === '0' && result.data) {
         const fetchedItemsCount = result.data.length;
         let total_count = skip + fetchedItemsCount;
-        if (fetchedItemsCount === pageSize) {
-          // If we fetched a full page, assume there's at least one more item to simulate more pages.
-          // The real API should provide the true total_count.
-          total_count += 1;
-        }
+        // A simplified mock pagination that assumes this is all the data
         result.metadata = {
           total_count: total_count,
           current_page: page,
-          total_pages: Math.ceil(total_count / pageSize),
-          has_next: total_count > page * pageSize,
-          has_previous: page > 1,
+          total_pages: page,
+          has_next: false,
+          has_previous: false,
         };
       }
       return result;


### PR DESCRIPTION
This pull request makes changes to the `job-api.ts` and `user-api.ts` files to adjust pagination behavior and increase the default page size for API requests. The most important changes involve simplifying the pagination logic and increasing the maximum number of items fetched per page.

### Adjustments to pagination behavior:
* [`app/lib/api/job-api.ts`](diffhunk://#diff-be522ba6a9dc1ccf097042c2de92861c6604b4f8d07b5bae1602fc1ce89591a4L41-R47): Simplified the pagination metadata by removing calculations for `has_next`, `has_previous`, and `total_pages`, assuming that all data is fetched in a single request.
* [`app/lib/api/user-api.ts`](diffhunk://#diff-320899a4b784c5f3cc3b5a4134695c632be46d8fc8578536006b187e9f480fd7L69-R75): Applied the same simplified pagination logic to the user API, removing assumptions about additional pages and reducing complexity.

### Increase in page size:
* [`app/lib/api/job-api.ts`](diffhunk://#diff-be522ba6a9dc1ccf097042c2de92861c6604b4f8d07b5bae1602fc1ce89591a4L32-R32): Increased the default `pageSize` from 10 to 1000 for job API requests to fetch more data per request.
* [`app/lib/api/user-api.ts`](diffhunk://#diff-320899a4b784c5f3cc3b5a4134695c632be46d8fc8578536006b187e9f480fd7L60-R60): Increased the default `pageSize` from 10 to 1000 for user API requests to align with the job API changes.… Title' and 'Select User(s)' dropdowns weren't loading. The previous pagination logic had a flaw that caused an infinite loop in certain situations. I've modified the `getJobs` and `getUsers` functions to fetch all records at once, which resolves the problem and ensures the dropdowns populate correctly.