### PR TITLE
Fix dropdowns not loading due to incorrect page number

### DIFF
--- a/app/dashboard/questions/page.tsx
+++ b/app/dashboard/questions/page.tsx
@@ -63,7 +63,7 @@ export default function QuestionsPage() {
   // Fetch job titles for dropdown
   const fetchJobTitles = async () => {
     try {
-      const response = await jobApi.getJobs(0, 100);
+      const response = await jobApi.getJobs(1, 100);
       if (response.code === '0' && response.data) {
         const titles = response.data.map(job => job.job_title);
         setJobTitles(titles);

--- a/app/dashboard/tests/page.tsx
+++ b/app/dashboard/tests/page.tsx
@@ -99,7 +99,7 @@ export default function TestsPage() {
   // Fetch user list
   const fetchUsers = async () => {
     try {
-      const response = await userApi.getUsers(0, 100);
+      const response = await userApi.getUsers(1, 100);
       if (response.code === '0' && response.data) {
         setUsers(response.data);
       }
@@ -111,7 +111,7 @@ export default function TestsPage() {
   // Fetch job list
   const fetchJobs = async () => {
     try {
-      const response = await jobApi.getJobs(0, 100);
+      const response = await jobApi.getJobs(1, 100);
       if (response.code === '0' && response.data) {
         setJobs(response.data);
       }


### PR DESCRIPTION
This pull request includes adjustments to API calls in two dashboard pages to correct the pagination offset from `0` to `1`. The changes ensure that the correct data is fetched from the APIs.

Updates to API calls:

* [`app/dashboard/questions/page.tsx`](diffhunk://#diff-f5d8ca548b5852168b3d3461c543b5673f7f586d57096f07d588d39d4e382447L66-R66): Modified the `fetchJobTitles` function to use an offset of `1` instead of `0` when fetching job titles.
* [`app/dashboard/tests/page.tsx`](diffhunk://#diff-df024228c77cf8b40bdf88c443fcfc831560e173fcb04184c27b0ad46079fe52L102-R102): Updated the `fetchUsers` and `fetchJobs` functions to use an offset of `1` instead of `0` when fetching user and job data. [[1]](diffhunk://#diff-df024228c77cf8b40bdf88c443fcfc831560e173fcb04184c27b0ad46079fe52L102-R102) [[2]](diffhunk://#diff-df024228c77cf8b40bdf88c443fcfc831560e173fcb04184c27b0ad46079fe52L114-R114)The 'Applicable Job Title' and 'Select User(s)' dropdowns were not loading because the API calls to fetch the data were using an incorrect page number (0 instead of 1). This resulted in the API not returning any data, and the dropdowns remained empty.

This commit fixes the issue by changing the page number to 1 in the `fetchJobTitles` and `fetchUsers` functions in `app/dashboard/questions/page.tsx` and `app/dashboard/tests/page.tsx`. This ensures that the data is fetched correctly and the dropdowns are populated as expected.